### PR TITLE
Add namespace to the obfuscated string definition macro

### DIFF
--- a/Lib/MetaString.h
+++ b/Lib/MetaString.h
@@ -134,7 +134,7 @@ namespace andrivet { namespace ADVobfuscator {
 }}
 
 // Prefix notation
-#define DEF_OBFUSCATED(str) MetaString<andrivet::ADVobfuscator::MetaRandom<__COUNTER__, 3>::value, andrivet::ADVobfuscator::MetaRandomChar<__COUNTER__>::value, Make_Indexes<sizeof(str) - 1>::type>(str)
+#define DEF_OBFUSCATED(str) andrivet::ADVobfuscator::MetaString<andrivet::ADVobfuscator::MetaRandom<__COUNTER__, 3>::value, andrivet::ADVobfuscator::MetaRandomChar<__COUNTER__>::value, andrivet::ADVobfuscator::Make_Indexes<sizeof(str) - 1>::type>(str)
 
 #define OBFUSCATED(str) (DEF_OBFUSCATED(str).decrypt())
 


### PR DESCRIPTION
Just a small change that makes sure that the `DEF_OBFUSCATED` macro uses the fully qualified names. Then the macro can be used without `using andrivet::ADVobfuscator;` which avoids clobbering the current namespace.