### PR TITLE
Fix CMake install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,24 +20,25 @@ install(TARGETS advobfuscator EXPORT advobfuscatorTargets)
 install(EXPORT advobfuscatorTargets
         FILE advobfuscatorTargets.cmake
         NAMESPACE advobfuscator::
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/advobfuscator
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/advobfuscator
 )
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
-        "${CMAKE_CURRENT_BINARY_DIR}/mylibConfigVersion.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/advobfuscatorConfigVersion.cmake"
         VERSION ${PROJECT_VERSION}
         COMPATIBILITY SameMajorVersion
+        ARCH_INDEPENDENT
 )
 configure_package_config_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/cmake/AdvobfuscatorConfig.cmake.in"
         "${CMAKE_CURRENT_BINARY_DIR}/advobfuscatorConfig.cmake"
-        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/advobfuscator
+        INSTALL_DESTINATION ${CMAKE_INSTALL_DATADIR}/advobfuscator
 )
 install(FILES
         "${CMAKE_CURRENT_BINARY_DIR}/advobfuscatorConfig.cmake"
         "${CMAKE_CURRENT_BINARY_DIR}/advobfuscatorConfigVersion.cmake"
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/advobfuscator
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/advobfuscator
 )
 
 if(BUILD_TESTING)


### PR DESCRIPTION
While updating the port for vcpkg, I noticed a few issues:
- Wrong version file (`mylibConfigVersion` instead of `advobfuscatorConfigVersion`)
- As this is a header-only library `ARCH_INDEPENDENT` could be added
- Use `CMAKE_INSTALL_DATADIR` as install dir, which is more robust than `${CMAKE_INSTALL_LIBDIR}/cmake`