### PR TITLE
Fix MSVC compilation error in AesString::decrypt()

### DIFF
--- a/include/advobfuscator/aes_string.h
+++ b/include/advobfuscator/aes_string.h
@@ -68,7 +68,7 @@ namespace andrivet::advobfuscator {
     [[nodiscard]] constexpr std::string decrypt() const {
       std::array<std::uint8_t, N> buffer;
       std::copy(data_.begin(), data_.end(), buffer.begin());
-      if(encrypted_) decrypt_ctr(buffer.begin(), N, key_, nonce_);
+      if(encrypted_) decrypt_ctr(buffer.data(), N, key_, nonce_);
       std::string str;
       str.resize(N - 1);
       std::copy(buffer.begin(), buffer.end() - 1, str.begin());


### PR DESCRIPTION
Use buffer.data() instead of buffer.begin() to get raw pointer from std::array.
MSVC's std::_Array_iterator doesn't implicitly convert to Byte*, causing compilation failure in guessme_aes example.

std::array::data() is the direct and standard way to provide that pointer type across compilers, so there is no issue or regression in GCC/Clang.

I validated the following builds/tests:
  - MSVC 19.44 (Visual Studio 2022)
  - GCC 15.2.0 (MSYS2 MinGW64 g++)
  - Clang 21.1.8 (MSYS2 clang64 clang++)