### PR TITLE
Fix invoke call to include object parameter

### DIFF
--- a/include/advobfuscator/call.h
+++ b/include/advobfuscator/call.h
@@ -67,7 +67,7 @@ namespace andrivet::advobfuscator {
         return;
       }
       else
-        return std::invoke(fn, args...);
+        return std::invoke(fn, o, args...);
     }
 
     Fsm<F> fsm_;


### PR DESCRIPTION
## Description

Fix missing object parameter `o` in `else` branch of `ObfuscatedMethodCall::operator()`.

## Problem

The `else` branch in the commented-out code block at lines 65-70 of `include/advobfuscator/call.h` is missing the object parameter `o` when calling `std::invoke`, which will cause a compilation error when the commented code is enabled.

## Changes

**File:** `include/advobfuscator/call.h`

| Before | After |
|--------|-------|
| `return std::invoke(fn, args...);` | `return std::invoke(fn, o, args...);` |

### Key Modifications
- Added missing object parameter `o` to `std::invoke` call in the `else` branch
- Ensures consistent member function invocation across both branches

## Testing

- [x] Code review completed
- [x] Fix validated against expected behavior

## Checklist

- [x] Verified the fix matches the expected behavior described in the issue
- [x] Ensured consistency with the `if constexpr` branch
- [x] No other occurrences of similar pattern in the codebase

---

**Related Issue:** [#49 (Bug in ObfuscatedMethodCall::operator() - Missing object parameter o in else branch)](https://github.com/andrivet/ADVobfuscator/issues/49)